### PR TITLE
feat: disable app timeout

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,6 @@
 import document from 'document';
 import * as messaging from 'messaging';
+import { me } from "appbit";
 import MessageBroker from '../common/message-broker';
 import * as Commands from '../common/commands';
 import Ui from './ui';
@@ -13,6 +14,8 @@ import Logo from './components/logo';
 import PhysicalButtons from './components/physical-buttons';
 import OnScreenButtons from './components/on-screen-buttons';
 import Menu from './components/menu';
+
+me.appTimeoutEnabled = false; 
 
 const broker = new MessageBroker('[FitBit]');
 


### PR DESCRIPTION
> All apps targeting SDK 2.0 will now automatically terminate after 2 minutes of inactivity (after the display turns off). Users will now see their clock after waking the device again

Refer to https://dev.fitbit.com/blog/2018-10-05-announcing-fitbit-os-2.2/#app-timeout-api

**TODO**
- [ ] Add smarts to only enable the flag whilst the player is active -- set a timeout to check/disable if required.