### PR TITLE
Add rhea to buildTargets

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     ],
     "buildTargets": [
       "atlas",
-      "hera"
+      "hera",
+      "rhea"
     ],
     "i18n": {
       "en": {


### PR DESCRIPTION
Added "rhea" to "buildTargets" to support the sense 2